### PR TITLE
Add type assertion to dns request builders

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -119,11 +119,12 @@ func getSPF(targetHostName string, dnsServer string) (bool, string, error) {
 
 	if len(in.Answer) != 0 {
 		for n := range in.Answer {
-			t := *in.Answer[n].(*dns.TXT)
-			for _, v := range t.Txt {
-				if strings.HasPrefix(v, "v=spf1") {
-					spf = true
-					spfanswer = in.Answer[n].String()
+			if t, ok := in.Answer[n].(*dns.TXT); ok {
+				for _, v := range t.Txt {
+					if strings.HasPrefix(v, "v=spf1") {
+						spf = true
+						spfanswer = in.Answer[n].String()
+					}
 				}
 			}
 		}
@@ -151,10 +152,11 @@ func getMTASTS(targetHostName string, dnsServer string) (bool, error) {
 
 	if len(in.Answer) != 0 {
 		for n := range in.Answer {
-			t := *in.Answer[n].(*dns.TXT)
-			for _, v := range t.Txt {
-				if strings.HasPrefix(v, "v=STSv1") {
-					mtasts = true
+			if t, ok := in.Answer[n].(*dns.TXT); ok {
+				for _, v := range t.Txt {
+					if strings.HasPrefix(v, "v=STSv1") {
+						mtasts = true
+					}
 				}
 			}
 		}
@@ -183,37 +185,38 @@ func getDKIM(selector string, targetHostName string, dnsServer string) (dkim, er
 
 	if len(in.Answer) != 0 {
 		for n := range in.Answer {
-			t := *in.Answer[n].(*dns.TXT)
-			for _, v := range t.Txt {
-				if strings.HasPrefix(v, "v=DKIM1") {
-					dkimSplit := strings.Fields(v)
-					dkim.dkimset = true
-					dkim.selector = selector
-					dkim.version = "1"
-					for _, partDKIM := range dkimSplit {
-						if strings.HasPrefix(partDKIM, "g=") {
-							dkim.granularity = strings.TrimRight(strings.Split(partDKIM, "=")[1], ";")
-							continue
-						}
-						if strings.HasPrefix(partDKIM, "h=") {
-							dkim.accepAlgo = strings.TrimRight(strings.Split(partDKIM, "=")[1], ";")
-							continue
-						}
-						if strings.HasPrefix(partDKIM, "k=") {
-							dkim.keyType = strings.TrimRight(strings.Split(partDKIM, "=")[1], ";")
-							continue
-						}
-						if strings.HasPrefix(partDKIM, "n=") {
-							dkim.noteField = strings.TrimRight(strings.Split(partDKIM, "=")[1], ";")
-							continue
-						}
-						if strings.HasPrefix(partDKIM, "p=") {
-							dkim.publicKey = strings.TrimRight(strings.Split(partDKIM, "=")[1], ";")
-							continue
-						}
-						if strings.HasPrefix(partDKIM, "t=") {
-							dkim.testing = strings.TrimRight(strings.Split(partDKIM, "=")[1], ";")
-							continue
+			if t, ok := in.Answer[n].(*dns.TXT); ok {
+				for _, v := range t.Txt {
+					if strings.HasPrefix(v, "v=DKIM1") {
+						dkimSplit := strings.Fields(v)
+						dkim.dkimset = true
+						dkim.selector = selector
+						dkim.version = "1"
+						for _, partDKIM := range dkimSplit {
+							if strings.HasPrefix(partDKIM, "g=") {
+								dkim.granularity = strings.TrimRight(strings.Split(partDKIM, "=")[1], ";")
+								continue
+							}
+							if strings.HasPrefix(partDKIM, "h=") {
+								dkim.accepAlgo = strings.TrimRight(strings.Split(partDKIM, "=")[1], ";")
+								continue
+							}
+							if strings.HasPrefix(partDKIM, "k=") {
+								dkim.keyType = strings.TrimRight(strings.Split(partDKIM, "=")[1], ";")
+								continue
+							}
+							if strings.HasPrefix(partDKIM, "n=") {
+								dkim.noteField = strings.TrimRight(strings.Split(partDKIM, "=")[1], ";")
+								continue
+							}
+							if strings.HasPrefix(partDKIM, "p=") {
+								dkim.publicKey = strings.TrimRight(strings.Split(partDKIM, "=")[1], ";")
+								continue
+							}
+							if strings.HasPrefix(partDKIM, "t=") {
+								dkim.testing = strings.TrimRight(strings.Split(partDKIM, "=")[1], ";")
+								continue
+							}
 						}
 					}
 				}
@@ -243,11 +246,12 @@ func getDMARC(targetHostName string, dnsServer string) (dmarc, error) {
 
 	if len(in.Answer) != 0 {
 		for n := range in.Answer {
-			t := *in.Answer[n].(*dns.TXT)
-			for _, v := range t.Txt {
-				if strings.Contains(v, "v=DMARC1") {
-					dmarc.dmarcset = true
-					dmarc.dmarcfull = in.Answer[n].String()
+			if t, ok := in.Answer[n].(*dns.TXT); ok {
+				for _, v := range t.Txt {
+					if strings.Contains(v, "v=DMARC1") {
+						dmarc.dmarcset = true
+						dmarc.dmarcfull = in.Answer[n].String()
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR fixes crashes that may occur in the case if a `IN TXT` request gets non-TXT record in the response. See an example below:

```
mxcheck -s deckhouse.ru -b -d 8.8.8.8 -n

INFO:  2025/05/23 18:48:23 == Checking: deckhouse.ru ==
INFO:  2025/05/23 18:48:23 Found MX:
INFO:  2025/05/23 18:48:23          alt2.aspmx.l.google.com.
INFO:  2025/05/23 18:48:23          alt1.aspmx.l.google.com.
INFO:  2025/05/23 18:48:23          alt3.aspmx.l.google.com.
INFO:  2025/05/23 18:48:23          aspmx.l.google.com.
INFO:  2025/05/23 18:48:23          alt4.aspmx.l.google.com.
INFO:  2025/05/23 18:48:23 == Checking DMARC record ==
INFO:  2025/05/23 18:48:23 DMARC set
INFO:  2025/05/23 18:48:23 _dmarc.deckhouse.ru.	300	IN	TXT	"v=DMARC1; p=none; rua=mailto:dmarc@deckhouse.ru; ruf=mailto:dmarc@deckhouse.ru; sp=none"
INFO:  2025/05/23 18:48:23 == Checking for A record ==
INFO:  2025/05/23 18:48:23 IP address MX: 192.178.163.27
INFO:  2025/05/23 18:48:24 AS Number: 15169
INFO:  2025/05/23 18:48:24 AS Country: US
INFO:  2025/05/23 18:48:24 == Checking for PTR record ==
INFO:  2025/05/23 18:48:24 PTR entry: tt-in-f27.1e100.net.
INFO:  2025/05/23 18:48:24 PTR does not match MX record
INFO:  2025/05/23 18:48:24 == Checking for SPF record ==
INFO:  2025/05/23 18:48:25 SPF set
INFO:  2025/05/23 18:48:25 deckhouse.ru.	300	IN	TXT	"v=spf1 include:spf.flant.ru include:spf.unisender.com ~all"
INFO:  2025/05/23 18:48:25 == Checking for MTA-STS ==
panic: interface conversion: dns.RR is *dns.CNAME, not *dns.TXT

goroutine 1 [running]:
main.getMTASTS({0x16b9f6ef3?, 0x0?}, {0x16b9f6f06, 0x7})
	/Users/idrey/go/pkg/mod/github.com/steffenfritz/mxcheck@v1.6.2/dns.go:154 +0x298
main.main()
	/Users/idrey/go/pkg/mod/github.com/steffenfritz/mxcheck@v1.6.2/main.go:255 +0x186c
```

The crash has happened due to `CNAME` record in the response:

```
dig @8.8.8.8 _mta-sts.deckhouse.ru IN TXT

; <<>> DiG 9.10.6 <<>> @8.8.8.8 _mta-sts.deckhouse.ru IN TXT
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 17599
;; flags: qr rd ra; QUERY: 1, ANSWER: 7, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;_mta-sts.deckhouse.ru.		IN	TXT

;; ANSWER SECTION:
_mta-sts.deckhouse.ru.	268	IN	CNAME	deckhouse.ru.
deckhouse.ru.		268	IN	TXT	"_globalsign-domain-verification=KQ9gUWP1TEop3hP2L3U62hIdbwfc7mVu-IKyGCxjpS"
deckhouse.ru.		268	IN	TXT	"_globalsign-domain-verification=gK2FM9YqK5jN1avM61OGENXyqj1Z86uO7NaqIFNmhv"
deckhouse.ru.		268	IN	TXT	"google-site-verification=mw_nreoMq0C4NWjXARoO_d4Hc3pBC79-NxR2Nv-VCeE"
deckhouse.ru.		268	IN	TXT	"google-site-verification=I81jsBaHQhp-GOAgvkstdXys8EL6Rz3eAA7Hf_XTZZE"
deckhouse.ru.		268	IN	TXT	"yandex-verification: be8268bf123d37a3"
deckhouse.ru.		268	IN	TXT	"v=spf1 include:spf.flant.ru include:spf.unisender.com ~all"

;; Query time: 48 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Fri May 23 18:48:57 MSK 2025
;; MSG SIZE  rcvd: 521
```
 