### PR TITLE
Add -p flag  to disable port scan

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,6 +75,7 @@ func main() {
 	dkimSelector := flag.StringP("dkim-selector", "S", "",
 		"The DKIM selector. If set a DKIM check is performed on the provided service domain")
 	dnsServer := flag.StringP("dnsserver", "d", "8.8.8.8", "The dns server to be requested")
+	disablePortScan := flag.BoolP("disable-port-scan", "p", false, "Disable SMTP port scan")
 	mailFrom := flag.StringP("mailfrom", "f", "info@foo.wtf", "Set the mailFrom address")
 	mailTo := flag.StringP("mailto", "t", "info@baz.wtf", "Set the mailTo address")
 	noprompt := flag.BoolP("no-prompt", "n", false, "Answer yes to all questions")
@@ -287,121 +288,123 @@ func main() {
 			}
 		}
 
-		// Checking for open e-mail ports
-		InfoLogger.Println("== Checking for open e-mail ports ==")
-		openPorts := portScan(targetHost)
-		InfoLogger.Print("Open ports: ", openPorts)
+		if !*disablePortScan {
+			// Checking for open e-mail ports
+			InfoLogger.Println("== Checking for open e-mail ports ==")
+			openPorts := portScan(targetHost)
+			InfoLogger.Print("Open ports: ", openPorts)
 
-		if len(openPorts) == 0 {
-			InfoLogger.Println(Cyan("No open ports to connect to. I cannot check this host."))
-			continue
-		}
-		singlemx.openports = openPorts
-
-		var orresult openResult
-
-		for _, port := range openPorts {
-			if port == "25" {
-				InfoLogger.Println("== Checking for open relay on port " + port + " ==")
-				orresult, err = openRelay(*mailFrom, *mailTo, targetHost, port)
-				if err != nil {
-					WarningLogger.Println(err.Error())
-				}
-
-				// Server string
-				if len(orresult.serverstring) > 0 {
-					InfoLogger.Printf("Server Banner: %s", orresult.serverstring)
-					singlemx.serverstring = strings.ReplaceAll(orresult.serverstring, "\r\n", "")
-				}
-
-				// Sender accepted
-				singlemx.fakesender = orresult.senderboolresult
-				if orresult.senderboolresult {
-					InfoLogger.Println("Fake sender accepted.")
-				} else {
-					InfoLogger.Println("Fake sender not accepted.")
-				}
-
-				// Recipient accepted
-				singlemx.fakercpt = orresult.rcptboolresult
-				if orresult.rcptboolresult {
-					InfoLogger.Println("Recipient accepted.")
-				} else {
-					InfoLogger.Println("Recipient not accepted. Skipped further open relay tests.")
-				}
-
-				// Open Relay test
-				if orresult.orboolresult {
-					singlemx.openrelay = true
-					InfoLogger.Println(Red("Server is probably an open relay"))
-				} else {
-					InfoLogger.Println(Green("Server is not an open relay"))
-				}
-
-				// STARTTLS test
-				InfoLogger.Println("== Checking for STARTTLS on port 25 ==")
-
-				singlemx.starttls = orresult.starttlsbool
-				singlemx.starttlsversion = orresult.starttlsversion
-				if orresult.starttlsbool {
-					InfoLogger.Println(Green("STARTTLS supported"))
-					if orresult.starttlsversion == "TLS 1.3" || orresult.starttlsversion == "TLS 1.2" {
-						InfoLogger.Println(Green("STARTTLS - TLS Version: " + orresult.starttlsversion))
-					} else if orresult.starttlsversion == "TLS 1.1" {
-						InfoLogger.Println(Yellow("STARTTLS - TLS Version: " + orresult.starttlsversion))
-					} else {
-						InfoLogger.Println("STARTTLS - TLS Version: " + orresult.starttlsversion)
-					}
-				} else {
-					InfoLogger.Println(Cyan("STARTTLS not supported"))
-				}
-
-				if orresult.starttlsbool && orresult.starttlsvalid {
-					singlemx.tlscertvalid = true
-					InfoLogger.Println(Green("Certificate is valid"))
-				}
-
-				if orresult.starttlsbool && !orresult.starttlsvalid {
-					InfoLogger.Println(Red("Certificate not valid"))
-				}
-				// VRFY test
-				InfoLogger.Println("== Checking for VRFY support ==")
-				singlemx.vrfysupport = orresult.vrfybool
-				if orresult.vrfybool {
-					InfoLogger.Println(Red("VRFY command supported."))
-				} else {
-					InfoLogger.Println(Green("VRFY command not supported."))
-				}
-
+			if len(openPorts) == 0 {
+				InfoLogger.Println(Cyan("No open ports to connect to. I cannot check this host."))
+				continue
 			}
-			// TLS test
-			if port == "465" {
-				InfoLogger.Println("== Checking for TLS support on port " + port + " ==")
-				orresult.tlsversion, orresult.tlsbool, orresult.tlsvalid, err = tlsCheck(targetHost, port)
-				if err != nil {
-					InfoLogger.Println(err)
-				}
-				singlemx.tlsversion = orresult.tlsversion
-				if orresult.tlsbool {
-					InfoLogger.Println(Green("SMTPS supported"))
-					if orresult.tlsvalid {
-						InfoLogger.Println(Green("SMTPS TLS certificate valid"))
-					} else {
-						InfoLogger.Println(Yellow("SMTPS TLS certificate not valid"))
-					}
-					if orresult.tlsversion == "TLS 1.3" || orresult.tlsversion == "TLS 1.2" {
-						InfoLogger.Println(Green("SMTPS TLS Version: " + orresult.tlsversion))
-					} else if orresult.tlsversion == "TLS 1.1" {
-						InfoLogger.Println(Yellow("SMTPS TLS Version: " + orresult.tlsversion))
-					} else {
-						InfoLogger.Println("SMTPS TLS Version: " + orresult.tlsversion)
-					}
-				} else {
-					InfoLogger.Println(Cyan("SMTPS not supported"))
-				}
+			singlemx.openports = openPorts
 
-				runresult.mxresults = append(runresult.mxresults, singlemx)
-				println()
+			var orresult openResult
+
+			for _, port := range openPorts {
+				if port == "25" {
+					InfoLogger.Println("== Checking for open relay on port " + port + " ==")
+					orresult, err = openRelay(*mailFrom, *mailTo, targetHost, port)
+					if err != nil {
+						WarningLogger.Println(err.Error())
+					}
+
+					// Server string
+					if len(orresult.serverstring) > 0 {
+						InfoLogger.Printf("Server Banner: %s", orresult.serverstring)
+						singlemx.serverstring = strings.ReplaceAll(orresult.serverstring, "\r\n", "")
+					}
+
+					// Sender accepted
+					singlemx.fakesender = orresult.senderboolresult
+					if orresult.senderboolresult {
+						InfoLogger.Println("Fake sender accepted.")
+					} else {
+						InfoLogger.Println("Fake sender not accepted.")
+					}
+
+					// Recipient accepted
+					singlemx.fakercpt = orresult.rcptboolresult
+					if orresult.rcptboolresult {
+						InfoLogger.Println("Recipient accepted.")
+					} else {
+						InfoLogger.Println("Recipient not accepted. Skipped further open relay tests.")
+					}
+
+					// Open Relay test
+					if orresult.orboolresult {
+						singlemx.openrelay = true
+						InfoLogger.Println(Red("Server is probably an open relay"))
+					} else {
+						InfoLogger.Println(Green("Server is not an open relay"))
+					}
+
+					// STARTTLS test
+					InfoLogger.Println("== Checking for STARTTLS on port 25 ==")
+
+					singlemx.starttls = orresult.starttlsbool
+					singlemx.starttlsversion = orresult.starttlsversion
+					if orresult.starttlsbool {
+						InfoLogger.Println(Green("STARTTLS supported"))
+						if orresult.starttlsversion == "TLS 1.3" || orresult.starttlsversion == "TLS 1.2" {
+							InfoLogger.Println(Green("STARTTLS - TLS Version: " + orresult.starttlsversion))
+						} else if orresult.starttlsversion == "TLS 1.1" {
+							InfoLogger.Println(Yellow("STARTTLS - TLS Version: " + orresult.starttlsversion))
+						} else {
+							InfoLogger.Println("STARTTLS - TLS Version: " + orresult.starttlsversion)
+						}
+					} else {
+						InfoLogger.Println(Cyan("STARTTLS not supported"))
+					}
+
+					if orresult.starttlsbool && orresult.starttlsvalid {
+						singlemx.tlscertvalid = true
+						InfoLogger.Println(Green("Certificate is valid"))
+					}
+
+					if orresult.starttlsbool && !orresult.starttlsvalid {
+						InfoLogger.Println(Red("Certificate not valid"))
+					}
+					// VRFY test
+					InfoLogger.Println("== Checking for VRFY support ==")
+					singlemx.vrfysupport = orresult.vrfybool
+					if orresult.vrfybool {
+						InfoLogger.Println(Red("VRFY command supported."))
+					} else {
+						InfoLogger.Println(Green("VRFY command not supported."))
+					}
+
+				}
+				// TLS test
+				if port == "465" {
+					InfoLogger.Println("== Checking for TLS support on port " + port + " ==")
+					orresult.tlsversion, orresult.tlsbool, orresult.tlsvalid, err = tlsCheck(targetHost, port)
+					if err != nil {
+						InfoLogger.Println(err)
+					}
+					singlemx.tlsversion = orresult.tlsversion
+					if orresult.tlsbool {
+						InfoLogger.Println(Green("SMTPS supported"))
+						if orresult.tlsvalid {
+							InfoLogger.Println(Green("SMTPS TLS certificate valid"))
+						} else {
+							InfoLogger.Println(Yellow("SMTPS TLS certificate not valid"))
+						}
+						if orresult.tlsversion == "TLS 1.3" || orresult.tlsversion == "TLS 1.2" {
+							InfoLogger.Println(Green("SMTPS TLS Version: " + orresult.tlsversion))
+						} else if orresult.tlsversion == "TLS 1.1" {
+							InfoLogger.Println(Yellow("SMTPS TLS Version: " + orresult.tlsversion))
+						} else {
+							InfoLogger.Println("SMTPS TLS Version: " + orresult.tlsversion)
+						}
+					} else {
+						InfoLogger.Println(Cyan("SMTPS not supported"))
+					}
+
+					runresult.mxresults = append(runresult.mxresults, singlemx)
+					println()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hi Steffen,

Do you mind to add a flag to disable SMTP port scan? In my specific case I have Google SMTP relays configured as domain's MX records, so it does not make much sense to scan them, moreover it takes too long.

This PR itroduces `-p` flag that allow to skip SMTP port scan if it is no desired. The option naming might be confusing, but it allows to keep the current app logic.

Regards, Ilya